### PR TITLE
Handle nil options in Options.Apply

### DIFF
--- a/option_test.go
+++ b/option_test.go
@@ -58,6 +58,18 @@ func TestApply(t *testing.T) {
 			t.Errorf("got: %v, want: %v", got, want)
 		}
 	})
+
+	t.Run("fails on nil option", func(t *testing.T) {
+		_, got := Apply[Client](Client{},
+			OptionAPIKey("foo-api-key"),
+			Option[Client](nil),
+		)
+
+		want := "option 1 is nil"
+		if got.Error() != want {
+			t.Errorf("got: %v, want: %v", got, want)
+		}
+	})
 }
 
 func requireNoError(t *testing.T, err error) {

--- a/options.go
+++ b/options.go
@@ -20,6 +20,9 @@ func NewOptions[T any](options ...Option[T]) Options[T] {
 // Apply applies a list of options to t.
 func (o Options[T]) Apply(t T) (T, error) {
 	for i, option := range o {
+		if option == nil {
+			return t, fmt.Errorf("option %d is nil", i)
+		}
 		var err error
 		if t, err = option.Apply(t); err != nil {
 			return t, fmt.Errorf("failed to apply option %d: %w", i, err)

--- a/options.go
+++ b/options.go
@@ -23,6 +23,7 @@ func (o Options[T]) Apply(t T) (T, error) {
 		if option == nil {
 			return t, fmt.Errorf("option %d is nil", i)
 		}
+
 		var err error
 		if t, err = option.Apply(t); err != nil {
 			return t, fmt.Errorf("failed to apply option %d: %w", i, err)


### PR DESCRIPTION
## Summary
- guard against nil options in `Options.Apply`
- cover nil option case in unit tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685a1dbc781c8321a5c239fe20f4875e